### PR TITLE
Ability to configure stacktrace.app.packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ appenders:
     release: 1.0.0
     serverName: 10.0.0.1
     extra: {key1:'value1',key2:'value2'}
+    stacktraceAppPackages: ['com.example','com.foo']
 ```
 
 | Setting | Default | Description | Example Value |
@@ -52,6 +53,7 @@ appenders:
 | `release` | [empty] | The release version of your application | `1.0.0` |
 | `serverName` | [empty] | Override the server name (rather than looking it up dynamically) | `10.0.0.1` |
 | `extra` | [empty] | Extra data to be sent with errors (but not as tags) | `{key1:'value1',key2:'value2'}` |
+| `stacktraceAppPackages` | [empty] | List of package prefixes used by application code | `['com.example','com.foo']` |
 
 ## Maven Artifacts
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ appenders:
 | `extra` | [empty] | Extra data to be sent with errors (but not as tags) | `{key1:'value1',key2:'value2'}` |
 | `stacktraceAppPackages` | [empty] | List of package prefixes used by application code | `['com.example','com.foo']` |
 
+If you need to set configuration properties not listed above, append them to the `dsn` as described [here](https://docs.sentry.io/clients/java/config/#configuration-via-the-dsn).
+
 ## Maven Artifacts
 
 This project is available in the [Central Repository](http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.dhatim%22%20AND%20a%3A%22dropwizard-sentry%22). To add it to your project simply add the following dependency to your POM:

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.dhatim</groupId>
         <artifactId>root-oss</artifactId>
-        <version>11.0.0</version>
+        <version>12.1.0</version>
     </parent>
     <groupId>org.dhatim</groupId>
     <artifactId>dropwizard-sentry</artifactId>
@@ -40,6 +40,7 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-logback</artifactId>
+            <version>1.7.5</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/test/java/org/dhatim/dropwizard/sentry/logging/SentryAppenderFactoryTest.java
+++ b/src/test/java/org/dhatim/dropwizard/sentry/logging/SentryAppenderFactoryTest.java
@@ -42,11 +42,11 @@ public class SentryAppenderFactoryTest {
 
     @Test
     public void buildSentryAppenderShouldWorkWithValidConfiguration() {
-        final SentryAppenderFactory factory = new SentryAppenderFactory();
-        final String dsn = "https://user:pass@app.sentry.io/id";
+        SentryAppenderFactory factory = new SentryAppenderFactory();
+        factory.setDsn("https://user:pass@app.sentry.io/id");
 
         Appender<ILoggingEvent> appender
-                = factory.build(context, dsn, layoutFactory, levelFilterFactory, asyncAppenderFactory);
+                = factory.build(context, "", layoutFactory, levelFilterFactory, asyncAppenderFactory);
 
         assertThat(appender, instanceOf(AsyncAppender.class));
     }


### PR DESCRIPTION
See https://docs.sentry.io/clients/java/config/#in-application-stack-frames
This property is empty by default: this disables the sentry warning.
