### PR TITLE
Make contextTags configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,18 @@ appenders:
     inAppIncludes: ['com.example','com.foo']
 ```
 
-| Setting | Default | Description | Example Value |
-|---|---|---|---|
-| `threshold` | ALL | The minimum log level to send events to Sentry | `ERROR` |
-| [`dsn`](https://docs.sentry.io/platforms/java/configuration/#setting-the-dsn) |   | Data Source Name - format is `https://{PUBLIC_KEY}:{SECRET_KEY}@sentry.io/{PROJECT_ID}` | `https://foo:bar@sentry.io/12345` |
-| [`environment`](https://docs.sentry.io/platforms/java/configuration/#environment) | [empty] | The environment your application is running in |  `production` |
-| [`tags`](https://docs.sentry.io/platforms/java/configuration/#tags) | [empty] | Tags to be sent with each event | `tag1:value1,tag2,value2` |
-| `configurator` | [empty] | Specify a custom [`SentryConfigurator`](https://github.com/dhatim/dropwizard-sentry/blob/master/src/main/java/org/dhatim/dropwizard/sentry/SentryConfigurator.java) class | `com.example.MySentryConfigurator` |
-| [`release`](https://docs.sentry.io/platforms/java/configuration/#release) | [empty] | The release version of your application | `1.0.0` |
-| [`serverName`](https://docs.sentry.io/platforms/java/configuration/#server-name) | [empty] | Override the server name (rather than looking it up dynamically) | `10.0.0.1` |
-| [`inAppIncludes`](https://docs.sentry.io/platforms/java/configuration/#in-app-includes) | [empty] | List of package prefixes used by application code | `['com.example','com.foo']` |
-| [`inAppExcludes`](https://docs.sentry.io/platforms/java/configuration/#in-app-excludes) | [empty] | List of package prefixes not used by application code | `['com.thirdparty','com.anotherthirdparty']` |
+| Setting | Default | Description                                                                                                                                                               | Example Value                                |
+|---|---|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
+| `threshold` | ALL | The minimum log level to send events to Sentry                                                                                                                            | `ERROR`                                      |
+| [`dsn`](https://docs.sentry.io/platforms/java/configuration/#setting-the-dsn) |   | Data Source Name - format is `https://{PUBLIC_KEY}:{SECRET_KEY}@sentry.io/{PROJECT_ID}`                                                                                   | `https://foo:bar@sentry.io/12345`            |
+| [`environment`](https://docs.sentry.io/platforms/java/configuration/#environment) | [empty] | The environment your application is running in                                                                                                                            | `production`                                 |
+| [`tags`](https://docs.sentry.io/platforms/java/configuration/#tags) | [empty] | Tags to be sent with each event                                                                                                                                           | `tag1:value1,tag2,value2`                    |
+| `configurator` | [empty] | Specify a custom [`SentryConfigurator`](https://github.com/dhatim/dropwizard-sentry/blob/master/src/main/java/org/dhatim/dropwizard/sentry/SentryConfigurator.java) class | `com.example.MySentryConfigurator`           |
+| [`release`](https://docs.sentry.io/platforms/java/configuration/#release) | [empty] | The release version of your application                                                                                                                                   | `1.0.0`                                      |
+| [`serverName`](https://docs.sentry.io/platforms/java/configuration/#server-name) | [empty] | Override the server name (rather than looking it up dynamically)                                                                                                          | `10.0.0.1`                                   |
+| [`inAppIncludes`](https://docs.sentry.io/platforms/java/configuration/#in-app-includes) | [empty] | List of package prefixes used by application code                                                                                                                         | `['com.example','com.foo']`                  |
+| [`inAppExcludes`](https://docs.sentry.io/platforms/java/configuration/#in-app-excludes) | [empty] | List of package prefixes not used by application code                                                                                                                     | `['com.thirdparty','com.anotherthirdparty']` |
+| `contextTags` | [empty] | context tags names applied as Sentry tags to each event                                                                                                                   | `['contextTag1','contextTag2']`              |
 
 If you need to set configuration properties not listed above, append them to the `dsn` as described [here](https://docs.sentry.io/clients/java/config/#configuration-via-the-dsn).
 

--- a/README.md
+++ b/README.md
@@ -52,18 +52,18 @@ appenders:
     inAppIncludes: ['com.example','com.foo']
 ```
 
-| Setting | Default | Description                                                                                                                                                               | Example Value                                |
-|---|---|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|
-| `threshold` | ALL | The minimum log level to send events to Sentry                                                                                                                            | `ERROR`                                      |
-| [`dsn`](https://docs.sentry.io/platforms/java/configuration/#setting-the-dsn) |   | Data Source Name - format is `https://{PUBLIC_KEY}:{SECRET_KEY}@sentry.io/{PROJECT_ID}`                                                                                   | `https://foo:bar@sentry.io/12345`            |
-| [`environment`](https://docs.sentry.io/platforms/java/configuration/#environment) | [empty] | The environment your application is running in                                                                                                                            | `production`                                 |
-| [`tags`](https://docs.sentry.io/platforms/java/configuration/#tags) | [empty] | Tags to be sent with each event                                                                                                                                           | `tag1:value1,tag2,value2`                    |
-| `configurator` | [empty] | Specify a custom [`SentryConfigurator`](https://github.com/dhatim/dropwizard-sentry/blob/master/src/main/java/org/dhatim/dropwizard/sentry/SentryConfigurator.java) class | `com.example.MySentryConfigurator`           |
-| [`release`](https://docs.sentry.io/platforms/java/configuration/#release) | [empty] | The release version of your application                                                                                                                                   | `1.0.0`                                      |
-| [`serverName`](https://docs.sentry.io/platforms/java/configuration/#server-name) | [empty] | Override the server name (rather than looking it up dynamically)                                                                                                          | `10.0.0.1`                                   |
-| [`inAppIncludes`](https://docs.sentry.io/platforms/java/configuration/#in-app-includes) | [empty] | List of package prefixes used by application code                                                                                                                         | `['com.example','com.foo']`                  |
-| [`inAppExcludes`](https://docs.sentry.io/platforms/java/configuration/#in-app-excludes) | [empty] | List of package prefixes not used by application code                                                                                                                     | `['com.thirdparty','com.anotherthirdparty']` |
-| `contextTags` | [empty] | context tags names applied as Sentry tags to each event                                                                                                                   | `['contextTag1','contextTag2']`              |
+| Setting | Default | Description | Example Value |
+|---|---|---|---|
+| `threshold` | ALL | The minimum log level to send events to Sentry | `ERROR` |
+| [`dsn`](https://docs.sentry.io/platforms/java/configuration/#setting-the-dsn) |   | Data Source Name - format is `https://{PUBLIC_KEY}:{SECRET_KEY}@sentry.io/{PROJECT_ID}` | `https://foo:bar@sentry.io/12345` |
+| [`environment`](https://docs.sentry.io/platforms/java/configuration/#environment) | [empty] | The environment your application is running in |  `production` |
+| [`tags`](https://docs.sentry.io/platforms/java/configuration/#tags) | [empty] | Tags to be sent with each event | `tag1:value1,tag2,value2` |
+| `configurator` | [empty] | Specify a custom [`SentryConfigurator`](https://github.com/dhatim/dropwizard-sentry/blob/master/src/main/java/org/dhatim/dropwizard/sentry/SentryConfigurator.java) class | `com.example.MySentryConfigurator` |
+| [`release`](https://docs.sentry.io/platforms/java/configuration/#release) | [empty] | The release version of your application | `1.0.0` |
+| [`serverName`](https://docs.sentry.io/platforms/java/configuration/#server-name) | [empty] | Override the server name (rather than looking it up dynamically) | `10.0.0.1` |
+| [`inAppIncludes`](https://docs.sentry.io/platforms/java/configuration/#in-app-includes) | [empty] | List of package prefixes used by application code | `['com.example','com.foo']` |
+| [`inAppExcludes`](https://docs.sentry.io/platforms/java/configuration/#in-app-excludes) | [empty] | List of package prefixes not used by application code | `['com.thirdparty','com.anotherthirdparty']` |
+| `contextTags` | [empty] | context tags names applied as Sentry tags to each event | `['contextTag1','contextTag2']` |
 
 If you need to set configuration properties not listed above, append them to the `dsn` as described [here](https://docs.sentry.io/clients/java/config/#configuration-via-the-dsn).
 

--- a/src/main/java/org/dhatim/dropwizard/sentry/logging/SentryAppenderFactory.java
+++ b/src/main/java/org/dhatim/dropwizard/sentry/logging/SentryAppenderFactory.java
@@ -54,6 +54,9 @@ public class SentryAppenderFactory extends AbstractAppenderFactory<ILoggingEvent
     @JsonProperty
     public String configurator = null;
 
+    @JsonProperty
+    public List<String> contextTags = null;
+
     @Override
     public Appender<ILoggingEvent> build(LoggerContext context,
                                          String applicationName,
@@ -69,6 +72,7 @@ public class SentryAppenderFactory extends AbstractAppenderFactory<ILoggingEvent
         Optional.ofNullable(serverName).ifPresent(options::setServerName);
         Optional.ofNullable(inAppIncludes).ifPresent(inAppIncludes -> inAppIncludes.forEach(options::addInAppInclude));
         Optional.ofNullable(inAppExcludes).ifPresent(inAppExcludes -> inAppExcludes.forEach(options::addInAppExclude));
+        Optional.ofNullable(contextTags).ifPresent(contextTags -> contextTags.forEach(options::addContextTag));
         Optional.ofNullable(configurator).ifPresent(configurator -> {
             try {
                 Class<?> klass = Class.forName(configurator);

--- a/src/test/java/org/dhatim/dropwizard/sentry/logging/SentryAppenderFactoryTest.java
+++ b/src/test/java/org/dhatim/dropwizard/sentry/logging/SentryAppenderFactoryTest.java
@@ -7,15 +7,18 @@ import io.dropwizard.configuration.ConfigurationException;
 import io.dropwizard.logging.common.async.AsyncLoggingEventAppenderFactory;
 import io.dropwizard.logging.common.filter.ThresholdLevelFilterFactory;
 import io.dropwizard.logging.common.layout.DropwizardLayoutFactory;
+import io.sentry.SentryOptions;
 import io.sentry.logback.SentryAppender;
+import org.dhatim.dropwizard.sentry.SentryConfigurator;
+import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SentryAppenderFactoryTest {
 
@@ -48,6 +51,37 @@ public class SentryAppenderFactoryTest {
         Appender<ILoggingEvent> appender = factory.build(context, "", layoutFactory, levelFilterFactory, asyncAppenderFactory);
 
         assertThat(appender, instanceOf(SentryAppender.class));
+    }
+
+    @Test
+    void buildSentryAppenderFullConfiguration() {
+        SentryAppenderFactory factory = new SentryAppenderFactory();
+        factory.dsn = "https://user:pass@app.sentry.io/id";
+        factory.configurator = "org.dhatim.dropwizard.sentry.logging.SentryAppenderFactoryTest$CaptureSentryConfigurator";
+        factory.contextTags = List.of("contextTag1");
+        factory.release = "1.0.0";
+        factory.environment = "test";
+        factory.serverName = "10.0.0.1";
+
+        Appender<ILoggingEvent> appender = factory.build(context, "", layoutFactory, levelFilterFactory, asyncAppenderFactory);
+        assertThat(appender, instanceOf(SentryAppender.class));
+
+        SentryOptions capturedOptions = CaptureSentryConfigurator.capturedOptions;
+        assertNotNull(capturedOptions);
+
+        assertEquals("https://user:pass@app.sentry.io/id", capturedOptions.getDsn());
+        assertEquals("test", capturedOptions.getEnvironment());
+        assertEquals("1.0.0", capturedOptions.getRelease());
+        assertThat(capturedOptions.getContextTags(), IsIterableContainingInOrder.contains("contextTag1"));
+        assertEquals("10.0.0.1", capturedOptions.getServerName());
+    }
+
+    protected static class CaptureSentryConfigurator implements SentryConfigurator {
+        static SentryOptions capturedOptions;
+        @Override
+        public void configure(SentryOptions options) {
+            capturedOptions = options;
+        }
     }
 
 }


### PR DESCRIPTION
The early version of this library had a `mdcTags` that was configurable. Context tags are basically the replacement for that in newer versions of sentry-logback. Was hoping to upgrade an app that's still using the 2.X version of dropwizard-sentry, but would like the tags to still be configurable.